### PR TITLE
feat: add angular frontend

### DIFF
--- a/frontend/.browserslistrc
+++ b/frontend/.browserslistrc
@@ -1,0 +1,4 @@
+> 0.5%
+last 2 versions
+Firefox ESR
+not dead

--- a/frontend/.eslintrc.json
+++ b/frontend/.eslintrc.json
@@ -1,0 +1,21 @@
+{
+  "root": true,
+  "ignorePatterns": ["projects/**/*"],
+  "overrides": [
+    {
+      "files": ["*.ts"],
+      "extends": [
+        "plugin:@angular-eslint/recommended",
+        "plugin:@angular-eslint/template/process-inline-templates"
+      ],
+      "rules": {
+        "@angular-eslint/no-host-metadata-property": "off"
+      }
+    },
+    {
+      "files": ["*.html"],
+      "extends": ["plugin:@angular-eslint/template/recommended"],
+      "rules": {}
+    }
+  ]
+}

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -1,0 +1,7 @@
+/node_modules
+/dist
+/.angular
+/.nx
+/coverage
+/.vscode
+.DS_Store

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,0 +1,60 @@
+# RoomieMatch Frontend
+
+This Angular 17 single-page application provides a lightweight interface on top of the RoomieMatch ASP.NET backend. It offers authentication, room browsing, booking request management, and profile editing flows backed by the API located at `http://localhost:5000/api`.
+
+## Features
+- Email + password registration and login for seekers and owners.
+- Landing page with featured rooms and quick navigation.
+- Filterable rooms catalog with compatibility scores for seekers.
+- Room detail view with booking request submission for seekers.
+- Dashboard summarising rooms and latest requests.
+- Requests management surface with owner status updates.
+- Profile editor for managing personal information and interests.
+
+## Local development
+
+> **Note:** Package installation requires Node.js 18+ and access to the public npm registry.
+
+```bash
+cd frontend
+npm install
+npm start
+```
+
+The dev server runs on `http://localhost:4200` and proxies API calls directly to the backend using absolute URLs. Update `src/environments/environment*.ts` if you host the API elsewhere.
+
+## Testing
+
+Run unit tests with:
+
+```bash
+npm test
+```
+
+ESLint can be executed via:
+
+```bash
+npm run lint
+```
+
+## Environment variables
+
+Adjust the default API base URL by editing the environment files. During local development the application targets `http://localhost:5000/api` to match the default backend port.
+
+## Folder structure
+
+```
+frontend/
+├── src/
+│   ├── app/
+│   │   ├── core/              # Shared services, guards and models
+│   │   ├── features/          # Routed pages (auth, rooms, dashboard, etc.)
+│   │   ├── app.component.*    # Root shell and layout
+│   │   └── app.routes.ts      # Route definitions
+│   ├── environments/          # API configuration per build profile
+│   ├── main.ts                # Application bootstrap
+│   └── styles.scss            # Global theme styling
+├── angular.json               # Angular CLI project configuration
+└── package.json               # Dependencies and npm scripts
+```
+

--- a/frontend/angular.json
+++ b/frontend/angular.json
@@ -1,0 +1,86 @@
+{
+  "$schema": "./node_modules/@angular/cli/lib/config/schema.json",
+  "version": 1,
+  "defaultProject": "roomiematch",
+  "projects": {
+    "roomiematch": {
+      "projectType": "application",
+      "root": "",
+      "sourceRoot": "src",
+      "prefix": "app",
+      "architect": {
+        "build": {
+          "builder": "@angular-devkit/build-angular:browser",
+          "options": {
+            "outputPath": "dist/roomiematch",
+            "index": "src/index.html",
+            "main": "src/main.ts",
+            "polyfills": ["zone.js"],
+            "tsConfig": "tsconfig.app.json",
+            "inlineStyleLanguage": "scss",
+            "assets": [
+              "src/favicon.ico",
+              "src/assets"
+            ],
+            "styles": [
+              "src/styles.scss"
+            ],
+            "scripts": []
+          },
+          "configurations": {
+            "production": {
+              "budgets": [
+                {
+                  "type": "initial",
+                  "maximumWarning": "500kb",
+                  "maximumError": "1mb"
+                },
+                {
+                  "type": "anyComponentStyle",
+                  "maximumWarning": "10kb",
+                  "maximumError": "20kb"
+                }
+              ],
+              "outputHashing": "all"
+            }
+          }
+        },
+        "serve": {
+          "builder": "@angular-devkit/build-angular:dev-server",
+          "options": {
+            "browserTarget": "roomiematch:build"
+          },
+          "configurations": {
+            "production": {
+              "browserTarget": "roomiematch:build:production"
+            }
+          }
+        },
+        "test": {
+          "builder": "@angular-devkit/build-angular:karma",
+          "options": {
+            "polyfills": ["zone.js", "zone.js/testing"],
+            "tsConfig": "tsconfig.spec.json",
+            "assets": [
+              "src/favicon.ico",
+              "src/assets"
+            ],
+            "styles": [
+              "src/styles.scss"
+            ],
+            "scripts": []
+          }
+        },
+        "lint": {
+          "builder": "@angular-eslint/builder:lint",
+          "options": {
+            "lintFilePatterns": [
+              "src/**/*.ts",
+              "src/**/*.html"
+            ]
+          }
+        }
+      }
+    }
+  }
+}

--- a/frontend/karma.conf.js
+++ b/frontend/karma.conf.js
@@ -1,0 +1,29 @@
+module.exports = function (config) {
+  config.set({
+    basePath: '',
+    frameworks: ['jasmine', '@angular-devkit/build-angular'],
+    plugins: [
+      require('karma-jasmine'),
+      require('karma-chrome-launcher'),
+      require('karma-jasmine-html-reporter'),
+      require('karma-coverage'),
+      require('@angular-devkit/build-angular/plugins/karma')
+    ],
+    client: {
+      clearContext: false
+    },
+    coverageReporter: {
+      dir: require('path').join(__dirname, './coverage'),
+      subdir: '.',
+      reporters: [{ type: 'html' }, { type: 'text-summary' }]
+    },
+    reporters: ['progress', 'kjhtml'],
+    port: 9876,
+    colors: true,
+    logLevel: config.LOG_INFO,
+    autoWatch: true,
+    browsers: ['ChromeHeadless'],
+    singleRun: false,
+    restartOnFileChange: true
+  });
+};

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,43 @@
+{
+  "name": "roomiematch-frontend",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "start": "ng serve",
+    "build": "ng build",
+    "test": "ng test",
+    "lint": "ng lint"
+  },
+  "dependencies": {
+    "@angular/animations": "^17.3.0",
+    "@angular/common": "^17.3.0",
+    "@angular/compiler": "^17.3.0",
+    "@angular/core": "^17.3.0",
+    "@angular/forms": "^17.3.0",
+    "@angular/platform-browser": "^17.3.0",
+    "@angular/platform-browser-dynamic": "^17.3.0",
+    "@angular/router": "^17.3.0",
+    "rxjs": "^7.8.0",
+    "tslib": "^2.6.0",
+    "zone.js": "^0.14.0"
+  },
+  "devDependencies": {
+    "@angular-devkit/build-angular": "^17.3.1",
+    "@angular-eslint/builder": "^17.4.1",
+    "@angular-eslint/eslint-plugin": "^17.4.1",
+    "@angular-eslint/eslint-plugin-template": "^17.4.1",
+    "@angular-eslint/template-parser": "^17.4.1",
+    "@angular/cli": "^17.3.1",
+    "@angular/compiler-cli": "^17.3.0",
+    "@types/jasmine": "~5.1.0",
+    "eslint": "^8.57.0",
+    "jasmine-core": "~5.1.0",
+    "karma": "~6.4.0",
+    "karma-chrome-launcher": "~3.2.0",
+    "karma-coverage": "~2.2.0",
+    "karma-jasmine": "~5.1.0",
+    "karma-jasmine-html-reporter": "~2.1.0",
+    "sass": "^1.69.0",
+    "typescript": "~5.4.5"
+  }
+}

--- a/frontend/preview/index.html
+++ b/frontend/preview/index.html
@@ -1,0 +1,165 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>RoomieMatch Frontend Preview</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <style>
+    body {
+      margin: 0;
+      font-family: 'Inter', sans-serif;
+      background: linear-gradient(180deg, #f9fbff 0%, #ffffff 60%);
+      color: #101828;
+    }
+    header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: 1rem 2.5rem;
+      background: rgba(255,255,255,0.9);
+      border-bottom: 1px solid #e4e7ec;
+    }
+    header nav a {
+      margin-right: 1rem;
+      text-decoration: none;
+      color: #475467;
+      font-weight: 500;
+    }
+    header nav a.active {
+      color: #1d4ed8;
+    }
+    .button {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      padding: 0.55rem 1.2rem;
+      border-radius: 0.5rem;
+      font-weight: 600;
+      background: #1d4ed8;
+      color: #fff;
+      text-decoration: none;
+    }
+    .button--ghost {
+      background: transparent;
+      color: #1d4ed8;
+      border: 1px solid rgba(29, 78, 216, 0.25);
+    }
+    main {
+      padding: 2.5rem;
+    }
+    .card {
+      background: #fff;
+      border-radius: 1rem;
+      padding: 1.5rem;
+      border: 1px solid #e4e7ec;
+      box-shadow: 0 10px 35px -30px rgba(15, 23, 42, 0.35);
+    }
+    .hero {
+      max-width: 680px;
+      margin: 0 auto 2rem;
+      text-align: center;
+    }
+    .hero h1 {
+      font-size: 2.4rem;
+      margin-bottom: 0.5rem;
+    }
+    .hero p {
+      color: #475467;
+      line-height: 1.6;
+    }
+    .hero .actions {
+      display: flex;
+      justify-content: center;
+      gap: 1rem;
+      margin-top: 1.5rem;
+    }
+    .grid {
+      display: grid;
+      gap: 1.5rem;
+      grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    }
+    .room header {
+      display: flex;
+      justify-content: space-between;
+      align-items: baseline;
+      padding: 0;
+      border: none;
+      background: none;
+    }
+    .room .price {
+      font-weight: 700;
+      color: #1d4ed8;
+    }
+    .room p {
+      color: #475467;
+    }
+    footer {
+      padding: 1.5rem 2.5rem;
+      border-top: 1px solid #e4e7ec;
+      background: #f8fafc;
+      color: #667085;
+      font-size: 0.85rem;
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <div>
+      <strong>🏠 RoomieMatch</strong>
+    </div>
+    <nav>
+      <a class="active">Rooms</a>
+      <a>Dashboard</a>
+      <a>Requests</a>
+      <a>Profile</a>
+    </nav>
+    <div>
+      <a class="button button--ghost">Login</a>
+      <a class="button">Join now</a>
+    </div>
+  </header>
+  <main>
+    <section class="card hero">
+      <h1>Find the right roomie faster</h1>
+      <p>RoomieMatch pairs seekers and owners through compatibility scoring, verified requests, and live messaging.</p>
+      <div class="actions">
+        <a class="button">Browse rooms</a>
+        <a class="button button--ghost">Create free account</a>
+      </div>
+    </section>
+
+    <section>
+      <h2>Featured rooms</h2>
+      <div class="grid">
+        <article class="card room">
+          <header>
+            <h3>Sunny double room</h3>
+            <span class="price">$1,100/mo</span>
+          </header>
+          <p>Bright double room with private balcony in a shared apartment near downtown.</p>
+        </article>
+        <article class="card room">
+          <header>
+            <h3>Creative loft</h3>
+            <span class="price">$980/mo</span>
+          </header>
+          <p>Loft-style bedroom with co-working nook, ideal for remote workers.</p>
+        </article>
+        <article class="card room">
+          <header>
+            <h3>City view suite</h3>
+            <span class="price">$1,450/mo</span>
+          </header>
+          <p>Top-floor suite with skyline views and all bills included.</p>
+        </article>
+      </div>
+    </section>
+  </main>
+  <footer>
+    RoomieMatch demo frontend preview.
+  </footer>
+</body>
+</html>

--- a/frontend/src/app/app.component.html
+++ b/frontend/src/app/app.component.html
@@ -1,0 +1,31 @@
+<header class="topbar">
+  <a class="topbar__brand" routerLink="/">
+    <span class="logo">🏠</span>
+    <span>RoomieMatch</span>
+  </a>
+  <nav class="topbar__nav">
+    <a routerLink="/rooms" routerLinkActive="active">Rooms</a>
+    <a routerLink="/dashboard" routerLinkActive="active" *ngIf="isAuthenticated$ | async">Dashboard</a>
+    <a routerLink="/requests" routerLinkActive="active" *ngIf="isAuthenticated$ | async">Requests</a>
+    <a routerLink="/profile" routerLinkActive="active" *ngIf="isAuthenticated$ | async">Profile</a>
+  </nav>
+  <div class="topbar__actions">
+    <ng-container *ngIf="(isAuthenticated$ | async); else guestLinks">
+      <span class="user-pill">
+        <strong>{{ (user$ | async)?.displayName }}</strong>
+        <small *ngIf="role()">{{ role() }}</small>
+      </span>
+      <button type="button" class="button button--ghost" (click)="logout()">Logout</button>
+    </ng-container>
+    <ng-template #guestLinks>
+      <a routerLink="/login" class="button button--ghost">Login</a>
+      <a routerLink="/register" class="button">Join now</a>
+    </ng-template>
+  </div>
+</header>
+<main class="page">
+  <router-outlet></router-outlet>
+</main>
+<footer class="footer">
+  <p>RoomieMatch demo frontend. Built to interact with the ASP.NET backend.</p>
+</footer>

--- a/frontend/src/app/app.component.scss
+++ b/frontend/src/app/app.component.scss
@@ -1,0 +1,129 @@
+:host {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+  background: linear-gradient(180deg, #f9fbff 0%, #ffffff 60%);
+  color: #101828;
+  font-family: 'Inter', sans-serif;
+}
+
+.topbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1rem 2.5rem;
+  background: rgba(255, 255, 255, 0.9);
+  border-bottom: 1px solid #e4e7ec;
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  backdrop-filter: blur(12px);
+
+  &__brand {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    font-weight: 600;
+    font-size: 1.1rem;
+    cursor: pointer;
+    color: inherit;
+    text-decoration: none;
+  }
+
+  &__nav {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+
+    a {
+      color: #475467;
+      text-decoration: none;
+      font-weight: 500;
+      padding: 0.4rem 0.6rem;
+      border-radius: 0.4rem;
+
+      &.active,
+      &:hover {
+        background: rgba(53, 90, 255, 0.1);
+        color: #1d4ed8;
+      }
+    }
+  }
+
+  &__actions {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+  }
+}
+
+.button {
+  background: #1d4ed8;
+  color: #fff;
+  border: none;
+  padding: 0.55rem 1.2rem;
+  border-radius: 0.5rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+  text-decoration: none;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+
+  &:hover {
+    transform: translateY(-1px);
+    box-shadow: 0 10px 20px -12px rgba(29, 78, 216, 0.8);
+  }
+
+  &--ghost {
+    background: transparent;
+    color: #1d4ed8;
+    border: 1px solid rgba(29, 78, 216, 0.25);
+  }
+}
+
+.user-pill {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  font-size: 0.85rem;
+  line-height: 1.2;
+  color: #344054;
+}
+
+.page {
+  flex: 1 1 auto;
+  padding: 2.5rem;
+}
+
+.footer {
+  padding: 1.5rem 2.5rem;
+  border-top: 1px solid #e4e7ec;
+  background: #f8fafc;
+  font-size: 0.85rem;
+  color: #667085;
+}
+
+@media (max-width: 960px) {
+  .topbar {
+    flex-wrap: wrap;
+    gap: 1rem;
+    padding: 1rem;
+
+    &__nav {
+      order: 3;
+      width: 100%;
+      justify-content: center;
+      flex-wrap: wrap;
+    }
+
+    &__actions {
+      order: 2;
+    }
+  }
+
+  .page {
+    padding: 1.5rem;
+  }
+}

--- a/frontend/src/app/app.component.ts
+++ b/frontend/src/app/app.component.ts
@@ -1,0 +1,23 @@
+import { Component, computed, inject } from '@angular/core';
+import { RouterModule } from '@angular/router';
+import { AsyncPipe, NgIf } from '@angular/common';
+import { AuthService } from './core/services/auth.service';
+
+@Component({
+  selector: 'app-root',
+  standalone: true,
+  imports: [RouterModule, NgIf, AsyncPipe],
+  templateUrl: './app.component.html',
+  styleUrl: './app.component.scss'
+})
+export class AppComponent {
+  private readonly auth = inject(AuthService);
+  readonly user$ = this.auth.user$;
+  readonly isAuthenticated$ = this.auth.isAuthenticated$;
+
+  readonly role = computed(() => this.auth.currentUser()?.role ?? null);
+
+  logout(): void {
+    this.auth.logout();
+  }
+}

--- a/frontend/src/app/app.config.ts
+++ b/frontend/src/app/app.config.ts
@@ -1,0 +1,13 @@
+import { ApplicationConfig, provideZoneChangeDetection } from '@angular/core';
+import { provideRouter, withComponentInputBinding } from '@angular/router';
+import { provideHttpClient, withInterceptors } from '@angular/common/http';
+import { appRoutes } from './app.routes';
+import { authInterceptor } from './core/interceptors/auth.interceptor';
+
+export const appConfig: ApplicationConfig = {
+  providers: [
+    provideZoneChangeDetection({ eventCoalescing: true }),
+    provideRouter(appRoutes, withComponentInputBinding()),
+    provideHttpClient(withInterceptors([authInterceptor]))
+  ]
+};

--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -1,0 +1,44 @@
+import { Routes } from '@angular/router';
+import { authGuard } from './core/guards/auth.guard';
+
+export const appRoutes: Routes = [
+  {
+    path: '',
+    loadComponent: () => import('./features/landing/landing.component').then((m) => m.LandingComponent)
+  },
+  {
+    path: 'rooms',
+    loadComponent: () => import('./features/rooms/rooms-list.component').then((m) => m.RoomsListComponent)
+  },
+  {
+    path: 'rooms/:id',
+    loadComponent: () => import('./features/rooms/detail/room-detail.component').then((m) => m.RoomDetailComponent)
+  },
+  {
+    path: 'dashboard',
+    canActivate: [authGuard],
+    loadComponent: () => import('./features/dashboard/dashboard.component').then((m) => m.DashboardComponent)
+  },
+  {
+    path: 'requests',
+    canActivate: [authGuard],
+    loadComponent: () => import('./features/requests/requests.component').then((m) => m.RequestsComponent)
+  },
+  {
+    path: 'profile',
+    canActivate: [authGuard],
+    loadComponent: () => import('./features/profile/profile.component').then((m) => m.ProfileComponent)
+  },
+  {
+    path: 'login',
+    loadComponent: () => import('./features/auth/login/login.component').then((m) => m.LoginComponent)
+  },
+  {
+    path: 'register',
+    loadComponent: () => import('./features/auth/register/register.component').then((m) => m.RegisterComponent)
+  },
+  {
+    path: '**',
+    redirectTo: ''
+  }
+];

--- a/frontend/src/app/core/guards/auth.guard.ts
+++ b/frontend/src/app/core/guards/auth.guard.ts
@@ -1,0 +1,14 @@
+import { CanActivateFn, Router } from '@angular/router';
+import { inject } from '@angular/core';
+import { AuthService } from '../services/auth.service';
+
+export const authGuard: CanActivateFn = () => {
+  const auth = inject(AuthService);
+  const router = inject(Router);
+  const session = auth.currentUser();
+  if (session) {
+    return true;
+  }
+  router.navigate(['/login'], { queryParams: { returnUrl: router.url } });
+  return false;
+};

--- a/frontend/src/app/core/interceptors/auth.interceptor.ts
+++ b/frontend/src/app/core/interceptors/auth.interceptor.ts
@@ -1,0 +1,17 @@
+import { HttpInterceptorFn } from '@angular/common/http';
+import { inject } from '@angular/core';
+import { AuthService } from '../services/auth.service';
+
+export const authInterceptor: HttpInterceptorFn = (req, next) => {
+  const auth = inject(AuthService);
+  const token = auth.accessToken();
+  if (token) {
+    const cloned = req.clone({
+      setHeaders: {
+        Authorization: `Bearer ${token}`
+      }
+    });
+    return next(cloned);
+  }
+  return next(req);
+};

--- a/frontend/src/app/core/models/auth.models.ts
+++ b/frontend/src/app/core/models/auth.models.ts
@@ -1,0 +1,25 @@
+export interface AuthResponse {
+  accessToken: string;
+  refreshToken: string;
+  expiresAt: string;
+}
+
+export interface RegisterRequest {
+  email: string;
+  password: string;
+  displayName: string;
+  role: 'Owner' | 'Seeker';
+}
+
+export interface LoginRequest {
+  email: string;
+  password: string;
+}
+
+export interface SessionUser {
+  id: string;
+  email: string;
+  displayName: string;
+  role: 'Owner' | 'Seeker';
+  expiresAt: Date;
+}

--- a/frontend/src/app/core/models/request.model.ts
+++ b/frontend/src/app/core/models/request.model.ts
@@ -1,0 +1,16 @@
+export type BookingRequestStatus = 'Pending' | 'Approved' | 'Declined' | 'Withdrawn';
+
+export interface BookingRequest {
+  id: string;
+  roomId: string;
+  seekerId: string;
+  status: BookingRequestStatus;
+  note?: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface UpdateBookingRequestPayload {
+  status: BookingRequestStatus;
+  note?: string | null;
+}

--- a/frontend/src/app/core/models/room.model.ts
+++ b/frontend/src/app/core/models/room.model.ts
@@ -1,0 +1,17 @@
+export interface RoomSummary {
+  id: string;
+  title: string;
+  description: string;
+  city: string;
+  country: string;
+  pricePerMonthCents: number;
+  billsIncluded: boolean;
+  isPublished: boolean;
+  compatibilityScore?: number | null;
+  rationale?: string[] | null;
+}
+
+export interface CreateBookingPayload {
+  roomId: string;
+  note?: string | null;
+}

--- a/frontend/src/app/core/models/user.model.ts
+++ b/frontend/src/app/core/models/user.model.ts
@@ -1,0 +1,24 @@
+export interface UserProfile {
+  id: string;
+  email: string;
+  displayName: string;
+  role: 'Owner' | 'Seeker';
+  avatarUrl?: string | null;
+  city: string;
+  country: string;
+  onboardingComplete: boolean;
+  bio?: string | null;
+  interests?: string[];
+  habits?: string[];
+  personality?: string[];
+}
+
+export interface UpdateUserPayload {
+  displayName?: string;
+  bio?: string;
+  city?: string;
+  country?: string;
+  interests?: string[];
+  habits?: string[];
+  personality?: string[];
+}

--- a/frontend/src/app/core/services/api.service.ts
+++ b/frontend/src/app/core/services/api.service.ts
@@ -1,0 +1,25 @@
+import { inject, Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { environment } from '../../../environments/environment';
+
+@Injectable({ providedIn: 'root' })
+export class ApiService {
+  private readonly http = inject(HttpClient);
+  private readonly baseUrl = environment.apiUrl;
+
+  get<T>(path: string, options?: Record<string, unknown>) {
+    return this.http.get<T>(`${this.baseUrl}/${path}`, options);
+  }
+
+  post<T>(path: string, body: unknown, options?: Record<string, unknown>) {
+    return this.http.post<T>(`${this.baseUrl}/${path}`, body, options);
+  }
+
+  patch<T>(path: string, body: unknown, options?: Record<string, unknown>) {
+    return this.http.patch<T>(`${this.baseUrl}/${path}`, body, options);
+  }
+
+  delete<T>(path: string, options?: Record<string, unknown>) {
+    return this.http.delete<T>(`${this.baseUrl}/${path}`, options);
+  }
+}

--- a/frontend/src/app/core/services/auth.service.ts
+++ b/frontend/src/app/core/services/auth.service.ts
@@ -1,0 +1,129 @@
+import { Injectable, effect, inject, signal, computed } from '@angular/core';
+import { Router } from '@angular/router';
+import { BehaviorSubject, Observable, catchError, map, of, tap } from 'rxjs';
+import { toObservable } from '@angular/core/rxjs-interop';
+import { ApiService } from './api.service';
+import { AuthResponse, LoginRequest, RegisterRequest, SessionUser } from '../models/auth.models';
+import { UserProfile } from '../models/user.model';
+
+interface AuthState {
+  user: SessionUser | null;
+  profile: UserProfile | null;
+}
+
+@Injectable({ providedIn: 'root' })
+export class AuthService {
+  private readonly api = inject(ApiService);
+  private readonly router = inject(Router);
+  private readonly tokenStorageKey = 'roomiematch.accessToken';
+  private readonly refreshStorageKey = 'roomiematch.refreshToken';
+
+  private readonly state = signal<AuthState>({ user: null, profile: null });
+  private readonly isAuthenticatedSubject = new BehaviorSubject<boolean>(false);
+
+  private readonly userSignal = computed(() => this.state().profile);
+  private readonly sessionSignal = computed(() => this.state().user);
+  readonly user$ = toObservable(this.userSignal);
+  readonly session$ = toObservable(this.sessionSignal);
+  readonly isAuthenticated$ = this.isAuthenticatedSubject.asObservable();
+
+  constructor() {
+    const storedToken = this.getStoredToken();
+    if (storedToken) {
+      const session = this.decodeToken(storedToken);
+      if (session) {
+        this.state.update((current) => ({ ...current, user: session }));
+        this.isAuthenticatedSubject.next(true);
+        this.loadProfile().subscribe();
+      }
+    }
+
+    effect(() => {
+      const session = this.state().user;
+      if (!session) {
+        this.isAuthenticatedSubject.next(false);
+        return;
+      }
+      this.isAuthenticatedSubject.next(true);
+    });
+  }
+
+  login(payload: LoginRequest): Observable<SessionUser | null> {
+    return this.api.post<AuthResponse>('auth/login', payload).pipe(
+      map((response) => this.handleAuthResponse(response)),
+      catchError(() => {
+        return of(null);
+      })
+    );
+  }
+
+  register(payload: RegisterRequest): Observable<SessionUser | null> {
+    return this.api.post<AuthResponse>('auth/register', payload).pipe(
+      map((response) => this.handleAuthResponse(response)),
+      catchError(() => of(null))
+    );
+  }
+
+  logout(): void {
+    localStorage.removeItem(this.tokenStorageKey);
+    localStorage.removeItem(this.refreshStorageKey);
+    this.state.set({ user: null, profile: null });
+    this.router.navigate(['/']);
+  }
+
+  currentUser(): SessionUser | null {
+    return this.state().user;
+  }
+
+  accessToken(): string | null {
+    return localStorage.getItem(this.tokenStorageKey);
+  }
+
+  refreshProfile(): Observable<UserProfile | null> {
+    return this.loadProfile();
+  }
+
+  private loadProfile(): Observable<UserProfile | null> {
+    return this.api.get<UserProfile>('users/me').pipe(
+      tap((profile) => this.state.update((current) => ({ ...current, profile }))),
+      catchError(() => {
+        this.state.update((current) => ({ ...current, profile: null }));
+        return of(null);
+      })
+    );
+  }
+
+  private handleAuthResponse(response: AuthResponse): SessionUser | null {
+    localStorage.setItem(this.tokenStorageKey, response.accessToken);
+    localStorage.setItem(this.refreshStorageKey, response.refreshToken);
+    const session = this.decodeToken(response.accessToken, response.expiresAt);
+    if (session) {
+      this.state.update((current) => ({ ...current, user: session }));
+      this.loadProfile().subscribe();
+      return session;
+    }
+    return null;
+  }
+
+  private getStoredToken(): string | null {
+    return localStorage.getItem(this.tokenStorageKey);
+  }
+
+  private decodeToken(token: string, expiresAt?: string): SessionUser | null {
+    try {
+      const [, payload] = token.split('.');
+      const decoded = JSON.parse(atob(payload));
+      const expiry = expiresAt ? new Date(expiresAt) : new Date(decoded['exp'] * 1000);
+      return {
+        id: decoded['sub'],
+        email: decoded['email'] ?? '',
+        displayName: decoded['displayName'] ?? '',
+        role: decoded['role'] ?? decoded['http://schemas.microsoft.com/ws/2008/06/identity/claims/role'],
+        expiresAt: expiry
+      } as SessionUser;
+    } catch (error) {
+      console.error('Failed to decode token', error);
+      return null;
+    }
+  }
+}

--- a/frontend/src/app/core/services/requests.service.ts
+++ b/frontend/src/app/core/services/requests.service.ts
@@ -1,0 +1,22 @@
+import { inject, Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+import { ApiService } from './api.service';
+import { BookingRequest, UpdateBookingRequestPayload } from '../models/request.model';
+import { CreateBookingPayload } from '../models/room.model';
+
+@Injectable({ providedIn: 'root' })
+export class RequestsService {
+  private readonly api = inject(ApiService);
+
+  list(): Observable<BookingRequest[]> {
+    return this.api.get<BookingRequest[]>('requests');
+  }
+
+  create(payload: CreateBookingPayload): Observable<BookingRequest> {
+    return this.api.post<BookingRequest>('requests', payload);
+  }
+
+  update(id: string, payload: UpdateBookingRequestPayload): Observable<BookingRequest> {
+    return this.api.patch<BookingRequest>(`requests/${id}`, payload);
+  }
+}

--- a/frontend/src/app/core/services/rooms.service.ts
+++ b/frontend/src/app/core/services/rooms.service.ts
@@ -1,0 +1,19 @@
+import { inject, Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+import { ApiService } from './api.service';
+import { RoomSummary } from '../models/room.model';
+
+@Injectable({ providedIn: 'root' })
+export class RoomsService {
+  private readonly api = inject(ApiService);
+
+  listRooms(seekerId?: string): Observable<RoomSummary[]> {
+    const params = seekerId ? { params: { seekerId } } : undefined;
+    return this.api.get<RoomSummary[]>('rooms', params);
+  }
+
+  getRoom(id: string, seekerId?: string): Observable<RoomSummary> {
+    const params = seekerId ? { params: { seekerId } } : undefined;
+    return this.api.get<RoomSummary>(`rooms/${id}`, params);
+  }
+}

--- a/frontend/src/app/core/services/users.service.ts
+++ b/frontend/src/app/core/services/users.service.ts
@@ -1,0 +1,17 @@
+import { inject, Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+import { ApiService } from './api.service';
+import { UpdateUserPayload, UserProfile } from '../models/user.model';
+
+@Injectable({ providedIn: 'root' })
+export class UsersService {
+  private readonly api = inject(ApiService);
+
+  me(): Observable<UserProfile> {
+    return this.api.get<UserProfile>('users/me');
+  }
+
+  updateMe(payload: UpdateUserPayload): Observable<UserProfile> {
+    return this.api.patch<UserProfile>('users/me', payload);
+  }
+}

--- a/frontend/src/app/features/auth/login/login.component.html
+++ b/frontend/src/app/features/auth/login/login.component.html
@@ -1,0 +1,23 @@
+<section class="auth">
+  <div class="card auth__card">
+    <h1>Sign in</h1>
+    <p>Access your RoomieMatch dashboard and start collaborating.</p>
+
+    <form [formGroup]="form" (ngSubmit)="submit()" class="form">
+      <div class="form-field">
+        <label for="email">Email</label>
+        <input id="email" type="email" formControlName="email" placeholder="you@example.com" />
+      </div>
+      <div class="form-field">
+        <label for="password">Password</label>
+        <input id="password" type="password" formControlName="password" placeholder="••••••" />
+      </div>
+      <button class="button" type="submit" [disabled]="loading()">{{ loading() ? 'Signing in…' : 'Sign in' }}</button>
+      <p class="error" *ngIf="error()">{{ error() }}</p>
+    </form>
+
+    <p class="switch">
+      New to RoomieMatch? <a routerLink="/register">Create an account</a>
+    </p>
+  </div>
+</section>

--- a/frontend/src/app/features/auth/login/login.component.scss
+++ b/frontend/src/app/features/auth/login/login.component.scss
@@ -1,0 +1,38 @@
+.auth {
+  display: flex;
+  justify-content: center;
+  padding: 3rem 1rem;
+}
+
+.auth__card {
+  max-width: 420px;
+  width: 100%;
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+
+  p {
+    color: #667085;
+  }
+
+  .form {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+  }
+
+  .error {
+    color: #dc2626;
+    font-weight: 600;
+  }
+
+  .switch {
+    color: #475467;
+
+    a {
+      color: #1d4ed8;
+      font-weight: 600;
+    }
+  }
+}

--- a/frontend/src/app/features/auth/login/login.component.ts
+++ b/frontend/src/app/features/auth/login/login.component.ts
@@ -1,0 +1,44 @@
+import { Component, inject, signal } from '@angular/core';
+import { Router, RouterLink } from '@angular/router';
+import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
+import { NgIf } from '@angular/common';
+import { AuthService } from '../../../core/services/auth.service';
+
+@Component({
+  standalone: true,
+  selector: 'app-login',
+  templateUrl: './login.component.html',
+  styleUrl: './login.component.scss',
+  imports: [ReactiveFormsModule, RouterLink, NgIf]
+})
+export class LoginComponent {
+  private readonly authService = inject(AuthService);
+  private readonly router = inject(Router);
+  private readonly fb = inject(FormBuilder);
+
+  readonly form = this.fb.group({
+    email: ['', [Validators.required, Validators.email]],
+    password: ['', [Validators.required]]
+  });
+
+  readonly error = signal<string>('');
+  readonly loading = signal<boolean>(false);
+
+  submit(): void {
+    if (this.form.invalid) {
+      this.form.markAllAsTouched();
+      return;
+    }
+
+    this.loading.set(true);
+    this.error.set('');
+    this.authService.login(this.form.value as { email: string; password: string }).subscribe((session) => {
+      this.loading.set(false);
+      if (!session) {
+        this.error.set('Could not sign in with those credentials');
+        return;
+      }
+      this.router.navigate(['/dashboard']);
+    });
+  }
+}

--- a/frontend/src/app/features/auth/register/register.component.html
+++ b/frontend/src/app/features/auth/register/register.component.html
@@ -1,0 +1,33 @@
+<section class="auth">
+  <div class="card auth__card">
+    <h1>Create your account</h1>
+    <p>Sign up as an owner or seeker to access tailored tools.</p>
+
+    <form [formGroup]="form" (ngSubmit)="submit()" class="form">
+      <div class="form-field">
+        <label for="displayName">Display name</label>
+        <input id="displayName" type="text" formControlName="displayName" placeholder="Alex Morgan" />
+      </div>
+      <div class="form-field">
+        <label for="email">Email</label>
+        <input id="email" type="email" formControlName="email" placeholder="you@example.com" />
+      </div>
+      <div class="form-field">
+        <label for="password">Password</label>
+        <input id="password" type="password" formControlName="password" placeholder="••••••" />
+      </div>
+      <div class="form-field">
+        <label for="role">Role</label>
+        <select id="role" formControlName="role">
+          <option *ngFor="let role of roles" [value]="role">{{ role }}</option>
+        </select>
+      </div>
+      <button class="button" type="submit" [disabled]="loading()">{{ loading() ? 'Creating…' : 'Create account' }}</button>
+      <p class="error" *ngIf="error()">{{ error() }}</p>
+    </form>
+
+    <p class="switch">
+      Already have an account? <a routerLink="/login">Sign in</a>
+    </p>
+  </div>
+</section>

--- a/frontend/src/app/features/auth/register/register.component.scss
+++ b/frontend/src/app/features/auth/register/register.component.scss
@@ -1,0 +1,1 @@
+@use '../login/login.component.scss' as *;

--- a/frontend/src/app/features/auth/register/register.component.ts
+++ b/frontend/src/app/features/auth/register/register.component.ts
@@ -1,0 +1,48 @@
+import { Component, inject, signal } from '@angular/core';
+import { Router, RouterLink } from '@angular/router';
+import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
+import { NgFor, NgIf } from '@angular/common';
+import { AuthService } from '../../../core/services/auth.service';
+
+@Component({
+  standalone: true,
+  selector: 'app-register',
+  templateUrl: './register.component.html',
+  styleUrl: './register.component.scss',
+  imports: [ReactiveFormsModule, RouterLink, NgIf, NgFor]
+})
+export class RegisterComponent {
+  private readonly authService = inject(AuthService);
+  private readonly router = inject(Router);
+  private readonly fb = inject(FormBuilder);
+
+  readonly roles = ['Owner', 'Seeker'];
+
+  readonly form = this.fb.group({
+    displayName: ['', [Validators.required]],
+    email: ['', [Validators.required, Validators.email]],
+    password: ['', [Validators.required, Validators.minLength(6)]],
+    role: ['Seeker', [Validators.required]]
+  });
+
+  readonly error = signal<string>('');
+  readonly loading = signal<boolean>(false);
+
+  submit(): void {
+    if (this.form.invalid) {
+      this.form.markAllAsTouched();
+      return;
+    }
+
+    this.loading.set(true);
+    this.error.set('');
+    this.authService.register(this.form.value as any).subscribe((session) => {
+      this.loading.set(false);
+      if (!session) {
+        this.error.set('Could not create the account');
+        return;
+      }
+      this.router.navigate(['/dashboard']);
+    });
+  }
+}

--- a/frontend/src/app/features/dashboard/dashboard.component.html
+++ b/frontend/src/app/features/dashboard/dashboard.component.html
@@ -1,0 +1,69 @@
+<div class="container dashboard" *ngIf="user$ | async as profile">
+  <section class="card welcome">
+    <div>
+      <p class="greeting">Welcome back,</p>
+      <h1>{{ profile.displayName }}</h1>
+      <p class="role">Logged in as {{ profile.role }}</p>
+    </div>
+    <div class="cta" *ngIf="isOwner()">
+      <p>Owners can publish new rooms from the backend or API. Use the requests tab to review seeker interest.</p>
+      <a routerLink="/requests" class="button button--ghost">Review requests</a>
+    </div>
+  </section>
+
+  <section class="grid columns">
+    <article class="card">
+      <header>
+        <h2>Your rooms</h2>
+        <button class="button button--ghost" type="button" (click)="refreshRooms()">
+          <span *ngIf="loadingRooms(); else refreshLabel">Refreshing…</span>
+          <ng-template #refreshLabel>Refresh via Rooms tab</ng-template>
+        </button>
+      </header>
+      <ng-container *ngIf="!loadingRooms(); else roomsLoading">
+        <ul class="list" *ngIf="rooms().length; else noRooms">
+          <li *ngFor="let room of rooms()">
+            <div>
+              <strong>{{ room.title }}</strong>
+              <span>{{ room.city }}, {{ room.country }}</span>
+            </div>
+            <div class="meta">
+              <span>{{ room.pricePerMonthCents / 100 | currency:'USD' }}/mo</span>
+              <span [class.published]="room.isPublished">{{ room.isPublished ? 'Published' : 'Draft' }}</span>
+            </div>
+          </li>
+        </ul>
+      </ng-container>
+      <ng-template #roomsLoading>
+        <p class="loading">Loading rooms…</p>
+      </ng-template>
+      <ng-template #noRooms>
+        <p class="empty">No rooms yet. Publish from the backend seeding or API.</p>
+      </ng-template>
+    </article>
+
+    <article class="card">
+      <header>
+        <h2>Latest requests</h2>
+        <a routerLink="/requests">View all</a>
+      </header>
+      <ng-container *ngIf="!loadingRequests(); else requestsLoading">
+        <ul class="list" *ngIf="requests().length; else noRequests">
+          <li *ngFor="let request of requests() | slice:0:5">
+            <div>
+              <strong>{{ request.status }}</strong>
+              <span>Request #{{ request.id | slice:0:8 }}</span>
+            </div>
+            <time>{{ request.createdAt | date:'mediumDate' }}</time>
+          </li>
+        </ul>
+      </ng-container>
+      <ng-template #requestsLoading>
+        <p class="loading">Loading requests…</p>
+      </ng-template>
+      <ng-template #noRequests>
+        <p class="empty">No requests yet. Encourage seekers to book your rooms.</p>
+      </ng-template>
+    </article>
+  </section>
+</div>

--- a/frontend/src/app/features/dashboard/dashboard.component.scss
+++ b/frontend/src/app/features/dashboard/dashboard.component.scss
@@ -1,0 +1,97 @@
+.dashboard {
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+.welcome {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 2rem;
+
+  .greeting {
+    color: #475467;
+  }
+
+  h1 {
+    font-size: clamp(2rem, 4vw, 2.5rem);
+  }
+
+  .role {
+    margin-top: 0.25rem;
+    color: #667085;
+  }
+
+  .cta {
+    max-width: 360px;
+    color: #475467;
+  }
+}
+
+.columns {
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+}
+
+.card header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 1rem;
+
+  a {
+    color: #1d4ed8;
+    font-weight: 600;
+    text-decoration: none;
+  }
+}
+
+.list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 1rem;
+
+  li {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 1rem;
+
+    strong {
+      display: block;
+      font-size: 1rem;
+    }
+
+    span,
+    time {
+      color: #667085;
+      font-size: 0.9rem;
+    }
+
+    .meta {
+      display: flex;
+      flex-direction: column;
+      align-items: flex-end;
+      gap: 0.25rem;
+
+      span.published {
+        color: #15803d;
+        font-weight: 600;
+      }
+    }
+  }
+}
+
+.loading,
+.empty {
+  color: #475467;
+}
+
+@media (max-width: 720px) {
+  .welcome {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+}

--- a/frontend/src/app/features/dashboard/dashboard.component.ts
+++ b/frontend/src/app/features/dashboard/dashboard.component.ts
@@ -1,0 +1,74 @@
+import { Component, inject, OnInit, signal } from '@angular/core';
+import { AsyncPipe, CurrencyPipe, DatePipe, NgFor, NgIf } from '@angular/common';
+import { RouterLink } from '@angular/router';
+import { AuthService } from '../../core/services/auth.service';
+import { RoomsService } from '../../core/services/rooms.service';
+import { RequestsService } from '../../core/services/requests.service';
+import { RoomSummary } from '../../core/models/room.model';
+import { BookingRequest } from '../../core/models/request.model';
+
+@Component({
+  standalone: true,
+  selector: 'app-dashboard',
+  templateUrl: './dashboard.component.html',
+  styleUrl: './dashboard.component.scss',
+  imports: [NgIf, NgFor, CurrencyPipe, DatePipe, RouterLink, AsyncPipe]
+})
+export class DashboardComponent implements OnInit {
+  private readonly authService = inject(AuthService);
+  private readonly roomsService = inject(RoomsService);
+  private readonly requestsService = inject(RequestsService);
+
+  readonly rooms = signal<RoomSummary[]>([]);
+  readonly requests = signal<BookingRequest[]>([]);
+  readonly loadingRooms = signal<boolean>(true);
+  readonly loadingRequests = signal<boolean>(true);
+
+  readonly user$ = this.authService.user$;
+
+  ngOnInit(): void {
+    if (!this.authService.currentUser()) {
+      return;
+    }
+    this.fetchRooms();
+    this.fetchRequests();
+  }
+
+  refreshRooms(): void {
+    this.fetchRooms();
+  }
+
+  refreshRequests(): void {
+    this.fetchRequests();
+  }
+
+  isOwner(): boolean {
+    return this.authService.currentUser()?.role === 'Owner';
+  }
+
+  private fetchRooms(): void {
+    const user = this.authService.currentUser();
+    if (!user) {
+      return;
+    }
+    this.loadingRooms.set(true);
+    this.roomsService.listRooms(user.role === 'Seeker' ? user.id : undefined).subscribe({
+      next: (rooms) => {
+        this.rooms.set(rooms);
+        this.loadingRooms.set(false);
+      },
+      error: () => this.loadingRooms.set(false)
+    });
+  }
+
+  private fetchRequests(): void {
+    this.loadingRequests.set(true);
+    this.requestsService.list().subscribe({
+      next: (requests) => {
+        this.requests.set(requests);
+        this.loadingRequests.set(false);
+      },
+      error: () => this.loadingRequests.set(false)
+    });
+  }
+}

--- a/frontend/src/app/features/landing/landing.component.html
+++ b/frontend/src/app/features/landing/landing.component.html
@@ -1,0 +1,52 @@
+<section class="hero">
+  <div class="container">
+    <div class="hero__content card">
+      <h1>Find the right roomie faster</h1>
+      <p>
+        RoomieMatch pairs seekers and owners through compatibility scoring, verified requests, and live messaging.
+        Explore available rooms or create an account to manage your listings.
+      </p>
+      <div class="hero__actions">
+        <a routerLink="/rooms" class="button">Browse rooms</a>
+        <a routerLink="/dashboard" class="button button--ghost" *ngIf="isAuthenticated$ | async">Go to dashboard</a>
+        <a routerLink="/register" class="button button--ghost" *ngIf="!(isAuthenticated$ | async)">Create free account</a>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section class="featured">
+  <div class="container">
+    <header>
+      <h2>Featured rooms</h2>
+      <a routerLink="/rooms">View all rooms →</a>
+    </header>
+    <div class="featured__grid" *ngIf="featuredRooms.length; else loading">
+      <article class="room" *ngFor="let room of featuredRooms">
+        <header>
+          <h3>{{ room.title }}</h3>
+          <span class="price">{{ room.pricePerMonthCents / 100 | currency:'USD' }}/mo</span>
+        </header>
+        <p>{{ room.description }}</p>
+        <dl>
+          <div>
+            <dt>Location</dt>
+            <dd>{{ room.city }}, {{ room.country }}</dd>
+          </div>
+          <div>
+            <dt>Status</dt>
+            <dd>{{ room.isPublished ? 'Published' : 'Draft' }}</dd>
+          </div>
+          <div *ngIf="room.compatibilityScore as score">
+            <dt>Match</dt>
+            <dd>{{ score | number:'1.0-0' }}% match</dd>
+          </div>
+        </dl>
+        <a class="room__link" [routerLink]="['/rooms', room.id]">Open details</a>
+      </article>
+    </div>
+    <ng-template #loading>
+      <p class="loading">Loading rooms…</p>
+    </ng-template>
+  </div>
+</section>

--- a/frontend/src/app/features/landing/landing.component.scss
+++ b/frontend/src/app/features/landing/landing.component.scss
@@ -1,0 +1,112 @@
+.hero {
+  padding: 2rem 0 1rem;
+
+  &__content {
+    text-align: center;
+    padding: 3rem;
+    background: linear-gradient(145deg, rgba(29, 78, 216, 0.06), rgba(255, 255, 255, 0.95));
+    border: 1px solid rgba(29, 78, 216, 0.12);
+
+    h1 {
+      font-size: clamp(2rem, 5vw, 2.7rem);
+      margin-bottom: 0.75rem;
+    }
+
+    p {
+      max-width: 640px;
+      margin: 0 auto 1.5rem;
+      line-height: 1.6;
+    }
+  }
+
+  &__actions {
+    display: flex;
+    justify-content: center;
+    gap: 1rem;
+    flex-wrap: wrap;
+  }
+}
+
+.featured {
+  padding: 1rem 0 3rem;
+
+  header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 1.5rem;
+
+    a {
+      color: #1d4ed8;
+      font-weight: 600;
+      text-decoration: none;
+    }
+  }
+
+  &__grid {
+    display: grid;
+    gap: 1.5rem;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  }
+}
+
+.room {
+  background: #fff;
+  border-radius: 1rem;
+  border: 1px solid #e4e7ec;
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.9rem;
+  box-shadow: 0 24px 36px -40px rgba(15, 23, 42, 0.45);
+
+  header {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+
+    .price {
+      font-weight: 700;
+      color: #1d4ed8;
+    }
+  }
+
+  dl {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 0.6rem 1rem;
+    margin: 0;
+
+    dt {
+      font-size: 0.75rem;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      color: #98a2b3;
+    }
+
+    dd {
+      margin: 0;
+      font-weight: 600;
+      color: #1d2939;
+    }
+  }
+
+  &__link {
+    text-decoration: none;
+    font-weight: 600;
+    color: #1d4ed8;
+  }
+}
+
+.loading {
+  text-align: center;
+  padding: 2rem 0;
+}
+
+@media (max-width: 720px) {
+  .hero {
+    &__content {
+      padding: 2rem;
+    }
+  }
+}

--- a/frontend/src/app/features/landing/landing.component.ts
+++ b/frontend/src/app/features/landing/landing.component.ts
@@ -1,0 +1,28 @@
+import { Component, inject, OnInit } from '@angular/core';
+import { RouterLink } from '@angular/router';
+import { AsyncPipe, CurrencyPipe, NgFor, NgIf } from '@angular/common';
+import { RoomsService } from '../../core/services/rooms.service';
+import { RoomSummary } from '../../core/models/room.model';
+import { AuthService } from '../../core/services/auth.service';
+
+@Component({
+  standalone: true,
+  selector: 'app-landing',
+  templateUrl: './landing.component.html',
+  styleUrl: './landing.component.scss',
+  imports: [RouterLink, NgFor, CurrencyPipe, NgIf, AsyncPipe]
+})
+export class LandingComponent implements OnInit {
+  private readonly roomsService = inject(RoomsService);
+  private readonly authService = inject(AuthService);
+
+  featuredRooms: RoomSummary[] = [];
+  readonly isAuthenticated$ = this.authService.isAuthenticated$;
+
+  ngOnInit(): void {
+    const seekerId = this.authService.currentUser()?.id;
+    this.roomsService.listRooms(seekerId ?? undefined).subscribe((rooms) => {
+      this.featuredRooms = rooms.slice(0, 3);
+    });
+  }
+}

--- a/frontend/src/app/features/profile/profile.component.html
+++ b/frontend/src/app/features/profile/profile.component.html
@@ -1,0 +1,51 @@
+<section class="container profile" *ngIf="profile() as current; else loading">
+  <article class="card">
+    <header>
+      <div>
+        <h1>Your profile</h1>
+        <p>Keep your information up to date so matches remain relevant.</p>
+      </div>
+      <p class="status" [class.complete]="current.onboardingComplete">
+        {{ current.onboardingComplete ? 'Onboarding complete' : 'Onboarding pending' }}
+      </p>
+    </header>
+
+    <form [formGroup]="form" (ngSubmit)="save()" class="form">
+      <div class="grid two-columns">
+        <div class="form-field">
+          <label for="displayName">Display name</label>
+          <input id="displayName" type="text" formControlName="displayName" required />
+        </div>
+        <div class="form-field">
+          <label for="bio">Bio</label>
+          <textarea id="bio" rows="3" formControlName="bio" placeholder="Share a short introduction"></textarea>
+        </div>
+        <div class="form-field">
+          <label for="city">City</label>
+          <input id="city" type="text" formControlName="city" />
+        </div>
+        <div class="form-field">
+          <label for="country">Country</label>
+          <input id="country" type="text" formControlName="country" />
+        </div>
+        <div class="form-field">
+          <label for="interests">Interests</label>
+          <input id="interests" type="text" formControlName="interests" placeholder="Comma separated" />
+        </div>
+        <div class="form-field">
+          <label for="habits">Habits</label>
+          <input id="habits" type="text" formControlName="habits" placeholder="Comma separated" />
+        </div>
+        <div class="form-field">
+          <label for="personality">Personality</label>
+          <input id="personality" type="text" formControlName="personality" placeholder="Comma separated" />
+        </div>
+      </div>
+      <button class="button" type="submit" [disabled]="saving()">{{ saving() ? 'Saving…' : 'Save changes' }}</button>
+      <p class="message" *ngIf="message()">{{ message() }}</p>
+    </form>
+  </article>
+</section>
+<ng-template #loading>
+  <p class="loading">Loading profile…</p>
+</ng-template>

--- a/frontend/src/app/features/profile/profile.component.scss
+++ b/frontend/src/app/features/profile/profile.component.scss
@@ -1,0 +1,55 @@
+.profile {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1.5rem;
+
+  p {
+    color: #667085;
+  }
+
+  .status {
+    padding: 0.4rem 0.85rem;
+    border-radius: 999px;
+    background: rgba(15, 23, 42, 0.08);
+    font-weight: 600;
+
+    &.complete {
+      background: rgba(34, 197, 94, 0.18);
+      color: #15803d;
+    }
+  }
+}
+
+.form {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+
+  .two-columns {
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  }
+}
+
+.message {
+  color: #15803d;
+  font-weight: 600;
+}
+
+.loading {
+  text-align: center;
+  color: #475467;
+}
+
+@media (max-width: 720px) {
+  header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+}

--- a/frontend/src/app/features/profile/profile.component.ts
+++ b/frontend/src/app/features/profile/profile.component.ts
@@ -1,0 +1,85 @@
+import { Component, inject, OnInit, signal } from '@angular/core';
+import { AsyncPipe, NgFor, NgIf } from '@angular/common';
+import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
+import { AuthService } from '../../core/services/auth.service';
+import { UsersService } from '../../core/services/users.service';
+import { UserProfile } from '../../core/models/user.model';
+
+@Component({
+  standalone: true,
+  selector: 'app-profile',
+  templateUrl: './profile.component.html',
+  styleUrl: './profile.component.scss',
+  imports: [ReactiveFormsModule, NgIf, NgFor, AsyncPipe]
+})
+export class ProfileComponent implements OnInit {
+  private readonly authService = inject(AuthService);
+  private readonly usersService = inject(UsersService);
+  private readonly fb = inject(FormBuilder);
+
+  readonly profile = signal<UserProfile | null>(null);
+  readonly saving = signal<boolean>(false);
+  readonly message = signal<string>('');
+
+  readonly form = this.fb.group({
+    displayName: ['', [Validators.required]],
+    city: [''],
+    country: [''],
+    bio: [''],
+    interests: [''],
+    habits: [''],
+    personality: ['']
+  });
+
+  ngOnInit(): void {
+    this.loadProfile();
+  }
+
+  loadProfile(): void {
+    this.authService.refreshProfile().subscribe((profile) => {
+      if (!profile) {
+        return;
+      }
+      this.profile.set(profile);
+      this.form.patchValue({
+        displayName: profile.displayName,
+        city: profile.city,
+        country: profile.country,
+        bio: profile.bio ?? '',
+        interests: profile.interests?.join(', ') ?? '',
+        habits: profile.habits?.join(', ') ?? '',
+        personality: profile.personality?.join(', ') ?? ''
+      });
+    });
+  }
+
+  save(): void {
+    if (this.form.invalid) {
+      this.form.markAllAsTouched();
+      return;
+    }
+    this.saving.set(true);
+    const value = this.form.value;
+    const payload = {
+      displayName: value.displayName ?? undefined,
+      city: value.city ?? undefined,
+      country: value.country ?? undefined,
+      bio: value.bio ?? undefined,
+      interests: value.interests ? value.interests.split(',').map((item) => item.trim()).filter(Boolean) : undefined,
+      habits: value.habits ? value.habits.split(',').map((item) => item.trim()).filter(Boolean) : undefined,
+      personality: value.personality ? value.personality.split(',').map((item) => item.trim()).filter(Boolean) : undefined
+    };
+
+    this.usersService.updateMe(payload).subscribe({
+      next: (profile) => {
+        this.profile.set(profile);
+        this.message.set('Profile updated');
+        this.saving.set(false);
+      },
+      error: () => {
+        this.message.set('Could not update profile');
+        this.saving.set(false);
+      }
+    });
+  }
+}

--- a/frontend/src/app/features/requests/requests.component.html
+++ b/frontend/src/app/features/requests/requests.component.html
@@ -1,0 +1,49 @@
+<section class="container requests">
+  <header class="card header">
+    <div>
+      <h1>Booking requests</h1>
+      <p>Review and track seeker interest in your rooms.</p>
+    </div>
+    <button class="button button--ghost" type="button" (click)="refresh()">Refresh</button>
+  </header>
+
+  <ng-container *ngIf="!loading(); else loadingState">
+    <article class="card request" *ngFor="let request of requests()">
+      <div class="request__meta">
+        <div>
+          <span class="label">Request ID</span>
+          <strong>{{ request.id }}</strong>
+        </div>
+        <div>
+          <span class="label">Submitted</span>
+          <time>{{ request.createdAt | date:'medium' }}</time>
+        </div>
+        <div>
+          <span class="label">Last updated</span>
+          <time>{{ request.updatedAt | date:'medium' }}</time>
+        </div>
+      </div>
+
+      <div class="request__status">
+        <label>Status</label>
+        <ng-container *ngIf="isOwner(); else statusView">
+          <select [value]="request.status" (change)="updateStatus(request, $any($event.target).value)">
+            <option *ngFor="let status of statuses" [value]="status">{{ status }}</option>
+          </select>
+        </ng-container>
+        <ng-template #statusView>
+          <p class="badge">{{ request.status }}</p>
+        </ng-template>
+      </div>
+
+      <div class="request__note" *ngIf="request.note">
+        <span class="label">Note from seeker</span>
+        <p>{{ request.note }}</p>
+      </div>
+    </article>
+    <p class="empty" *ngIf="!requests().length">No booking requests yet.</p>
+  </ng-container>
+</section>
+<ng-template #loadingState>
+  <p class="loading">Loading requests…</p>
+</ng-template>

--- a/frontend/src/app/features/requests/requests.component.scss
+++ b/frontend/src/app/features/requests/requests.component.scss
@@ -1,0 +1,91 @@
+.requests {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+
+  h1 {
+    margin-bottom: 0.3rem;
+  }
+
+  p {
+    color: #667085;
+  }
+}
+
+.request {
+  display: grid;
+  gap: 1.5rem;
+
+  &__meta {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    gap: 1rem;
+
+    .label {
+      display: block;
+      font-size: 0.75rem;
+      text-transform: uppercase;
+      letter-spacing: 0.06em;
+      color: #98a2b3;
+      margin-bottom: 0.25rem;
+    }
+
+    strong {
+      font-size: 1rem;
+      color: #1d2939;
+      word-break: break-all;
+    }
+  }
+
+  &__status {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+
+    select {
+      border-radius: 0.65rem;
+      border: 1px solid #d0d5dd;
+      padding: 0.6rem 0.75rem;
+      font: inherit;
+      max-width: 200px;
+    }
+
+    .badge {
+      display: inline-flex;
+      background: rgba(15, 23, 42, 0.08);
+      padding: 0.35rem 0.85rem;
+      border-radius: 999px;
+      font-weight: 600;
+      color: #1d2939;
+    }
+  }
+
+  &__note {
+    background: rgba(15, 23, 42, 0.05);
+    border-radius: 0.85rem;
+    padding: 1rem 1.25rem;
+    color: #475467;
+
+    .label {
+      font-size: 0.75rem;
+      text-transform: uppercase;
+      letter-spacing: 0.06em;
+      color: #98a2b3;
+      display: block;
+      margin-bottom: 0.35rem;
+    }
+  }
+}
+
+.loading,
+.empty {
+  text-align: center;
+  color: #475467;
+}

--- a/frontend/src/app/features/requests/requests.component.ts
+++ b/frontend/src/app/features/requests/requests.component.ts
@@ -1,0 +1,51 @@
+import { Component, inject, OnInit, signal } from '@angular/core';
+import { AsyncPipe, DatePipe, NgFor, NgIf } from '@angular/common';
+import { RequestsService } from '../../core/services/requests.service';
+import { BookingRequest, BookingRequestStatus } from '../../core/models/request.model';
+import { AuthService } from '../../core/services/auth.service';
+
+@Component({
+  standalone: true,
+  selector: 'app-requests',
+  templateUrl: './requests.component.html',
+  styleUrl: './requests.component.scss',
+  imports: [NgIf, NgFor, DatePipe, AsyncPipe]
+})
+export class RequestsComponent implements OnInit {
+  private readonly requestsService = inject(RequestsService);
+  private readonly authService = inject(AuthService);
+
+  readonly requests = signal<BookingRequest[]>([]);
+  readonly loading = signal<boolean>(true);
+  readonly statuses: BookingRequestStatus[] = ['Pending', 'Approved', 'Declined', 'Withdrawn'];
+  readonly isOwner = signal<boolean>(false);
+
+  ngOnInit(): void {
+    const user = this.authService.currentUser();
+    this.isOwner.set(user?.role === 'Owner');
+    this.refresh();
+  }
+
+  refresh(): void {
+    this.loading.set(true);
+    this.requestsService.list().subscribe({
+      next: (requests) => {
+        this.requests.set(requests);
+        this.loading.set(false);
+      },
+      error: () => this.loading.set(false)
+    });
+  }
+
+  updateStatus(request: BookingRequest, status: string): void {
+    if (!this.isOwner()) {
+      return;
+    }
+    const nextStatus = status as BookingRequestStatus;
+    this.requestsService.update(request.id, { status: nextStatus, note: request.note }).subscribe({
+      next: (updated) => {
+        this.requests.update((items) => items.map((item) => (item.id === updated.id ? updated : item)));
+      }
+    });
+  }
+}

--- a/frontend/src/app/features/rooms/detail/room-detail.component.html
+++ b/frontend/src/app/features/rooms/detail/room-detail.component.html
@@ -1,0 +1,51 @@
+<section class="container" *ngIf="!loading(); else loadingState">
+  <a routerLink="/rooms" class="back">← Back to list</a>
+  <article class="card room" *ngIf="room() as current">
+    <header>
+      <div>
+        <h1>{{ current.title }}</h1>
+        <p class="location">{{ current.city }}, {{ current.country }}</p>
+      </div>
+      <div class="pricing">
+        <span class="price">{{ current.pricePerMonthCents / 100 | currency:'USD' }}/month</span>
+        <span class="badge" [class.badge--green]="current.isPublished">
+          {{ current.isPublished ? 'Published' : 'Draft' }}
+        </span>
+      </div>
+    </header>
+
+    <p class="description">{{ current.description }}</p>
+
+    <section class="compatibility" *ngIf="current.compatibilityScore as score">
+      <h2>Compatibility</h2>
+      <div class="score">{{ score | number:'1.0-0' }}% match</div>
+      <ul>
+        <li *ngFor="let reason of current.rationale || []">{{ reason }}</li>
+      </ul>
+    </section>
+
+    <section class="actions" *ngIf="canRequest(); else requestCta">
+      <h2>Request a viewing</h2>
+      <textarea
+        rows="3"
+        placeholder="Share a bit about yourself"
+        [value]="requestNote()"
+        (input)="requestNote.set($any($event.target).value)">
+      </textarea>
+      <button class="button" (click)="submitRequest()" [disabled]="requestStatus() === 'submitting'">
+        {{ requestStatus() === 'submitting' ? 'Sending…' : 'Send request' }}
+      </button>
+      <p class="success" *ngIf="requestStatus() === 'success'">Request sent! The owner will reach out soon.</p>
+      <p class="error" *ngIf="requestStatus() === 'error'">Failed to send the request. Try again later.</p>
+    </section>
+    <ng-template #requestCta>
+      <p class="login-hint">
+        Sign in as a seeker to request this room.
+        <a routerLink="/login">Login</a>
+      </p>
+    </ng-template>
+  </article>
+</section>
+<ng-template #loadingState>
+  <p class="loading">Loading room…</p>
+</ng-template>

--- a/frontend/src/app/features/rooms/detail/room-detail.component.scss
+++ b/frontend/src/app/features/rooms/detail/room-detail.component.scss
@@ -1,0 +1,114 @@
+.back {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  text-decoration: none;
+  color: #1d4ed8;
+  font-weight: 600;
+  margin-bottom: 1rem;
+}
+
+.room {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+
+  header {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    gap: 1rem;
+  }
+
+  .location {
+    color: #667085;
+  }
+
+  .pricing {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+    gap: 0.5rem;
+
+    .price {
+      font-size: 1.4rem;
+      font-weight: 700;
+      color: #1d4ed8;
+    }
+  }
+
+  .badge {
+    padding: 0.35rem 0.75rem;
+    border-radius: 999px;
+    background: rgba(15, 23, 42, 0.08);
+    font-weight: 600;
+
+    &--green {
+      background: rgba(34, 197, 94, 0.18);
+      color: #15803d;
+    }
+  }
+
+  .compatibility {
+    background: rgba(29, 78, 216, 0.06);
+    border-radius: 0.75rem;
+    padding: 1.25rem;
+    border: 1px solid rgba(29, 78, 216, 0.1);
+
+    .score {
+      font-size: 1.5rem;
+      font-weight: 700;
+      color: #1d4ed8;
+      margin-bottom: 0.75rem;
+    }
+
+    ul {
+      margin: 0;
+      padding-left: 1.25rem;
+      color: #344054;
+      display: grid;
+      gap: 0.4rem;
+    }
+  }
+
+  .actions {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+
+    textarea {
+      border-radius: 0.75rem;
+      border: 1px solid #d0d5dd;
+      padding: 0.75rem;
+      font: inherit;
+      resize: vertical;
+    }
+
+    .success {
+      color: #15803d;
+      font-weight: 600;
+    }
+
+    .error {
+      color: #dc2626;
+      font-weight: 600;
+    }
+  }
+
+  .login-hint {
+    background: rgba(15, 23, 42, 0.05);
+    border-radius: 0.75rem;
+    padding: 1.25rem;
+    color: #475467;
+
+    a {
+      font-weight: 600;
+      color: #1d4ed8;
+    }
+  }
+}
+
+.loading {
+  text-align: center;
+  padding: 2rem 0;
+}

--- a/frontend/src/app/features/rooms/detail/room-detail.component.ts
+++ b/frontend/src/app/features/rooms/detail/room-detail.component.ts
@@ -1,0 +1,65 @@
+import { Component, inject, signal } from '@angular/core';
+import { ActivatedRoute, RouterLink } from '@angular/router';
+import { AsyncPipe, CurrencyPipe, NgFor, NgIf } from '@angular/common';
+import { RoomsService } from '../../../core/services/rooms.service';
+import { RoomSummary, CreateBookingPayload } from '../../../core/models/room.model';
+import { RequestsService } from '../../../core/services/requests.service';
+import { AuthService } from '../../../core/services/auth.service';
+
+@Component({
+  standalone: true,
+  selector: 'app-room-detail',
+  templateUrl: './room-detail.component.html',
+  styleUrl: './room-detail.component.scss',
+  imports: [RouterLink, CurrencyPipe, NgIf, NgFor, AsyncPipe]
+})
+export class RoomDetailComponent {
+  private readonly route = inject(ActivatedRoute);
+  private readonly roomsService = inject(RoomsService);
+  private readonly requestsService = inject(RequestsService);
+  private readonly authService = inject(AuthService);
+
+  readonly room = signal<RoomSummary | null>(null);
+  readonly loading = signal<boolean>(true);
+  readonly requestNote = signal<string>('');
+  readonly requestStatus = signal<'idle' | 'submitting' | 'success' | 'error'>('idle');
+
+  constructor() {
+    const id = this.route.snapshot.paramMap.get('id');
+    if (id) {
+      const seekerId = this.authService.currentUser()?.id;
+      this.roomsService.getRoom(id, seekerId ?? undefined).subscribe({
+        next: (room) => {
+          this.room.set(room);
+          this.loading.set(false);
+        },
+        error: () => this.loading.set(false)
+      });
+    }
+  }
+
+  canRequest(): boolean {
+    const user = this.authService.currentUser();
+    return !!user && user.role === 'Seeker';
+  }
+
+  submitRequest(): void {
+    const room = this.room();
+    const user = this.authService.currentUser();
+    if (!room || !user) {
+      return;
+    }
+    const payload: CreateBookingPayload = {
+      roomId: room.id,
+      note: this.requestNote()
+    };
+    this.requestStatus.set('submitting');
+    this.requestsService.create(payload).subscribe({
+      next: () => {
+        this.requestStatus.set('success');
+        this.requestNote.set('');
+      },
+      error: () => this.requestStatus.set('error')
+    });
+  }
+}

--- a/frontend/src/app/features/rooms/rooms-list.component.html
+++ b/frontend/src/app/features/rooms/rooms-list.component.html
@@ -1,0 +1,39 @@
+<section class="container">
+  <div class="card filter">
+    <h1>Available rooms</h1>
+    <div class="filter__controls">
+      <label>
+        <span>City or country</span>
+        <input type="text" placeholder="e.g. London" [value]="cityFilter()" (input)="cityFilter.set($any($event.target).value)" />
+      </label>
+      <label class="toggle">
+        <input type="checkbox" [checked]="onlyPublished()" (change)="onlyPublished.set($any($event.target).checked)" />
+        <span>Published only</span>
+      </label>
+      <button class="button button--ghost" type="button" (click)="loadRooms()">Refresh</button>
+    </div>
+  </div>
+
+  <div class="grid rooms" *ngIf="!loading(); else loadingState">
+    <article class="room card" *ngFor="let room of filteredRooms()">
+      <header>
+        <div>
+          <h2>{{ room.title }}</h2>
+          <p class="location">{{ room.city }}, {{ room.country }}</p>
+        </div>
+        <strong class="price">{{ room.pricePerMonthCents / 100 | currency:'USD' }}/mo</strong>
+      </header>
+      <p class="description">{{ room.description }}</p>
+      <div class="meta">
+        <span class="badge" [class.badge--green]="room.isPublished">{{ room.isPublished ? 'Published' : 'Draft' }}</span>
+        <span class="badge" *ngIf="room.billsIncluded">Bills included</span>
+        <span class="badge" *ngIf="room.compatibilityScore as score">Match: {{ score | number:'1.0-0' }}%</span>
+      </div>
+      <a class="button" [routerLink]="['/rooms', room.id]">View details</a>
+    </article>
+  </div>
+
+  <ng-template #loadingState>
+    <p class="loading">Loading rooms…</p>
+  </ng-template>
+</section>

--- a/frontend/src/app/features/rooms/rooms-list.component.scss
+++ b/frontend/src/app/features/rooms/rooms-list.component.scss
@@ -1,0 +1,82 @@
+.filter {
+  margin-bottom: 2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.2rem;
+
+  h1 {
+    font-size: 1.8rem;
+  }
+
+  &__controls {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1rem;
+    align-items: center;
+
+    label {
+      display: flex;
+      flex-direction: column;
+      gap: 0.4rem;
+      min-width: 200px;
+    }
+
+    .toggle {
+      flex-direction: row;
+      align-items: center;
+      gap: 0.5rem;
+      font-weight: 600;
+      color: #475467;
+    }
+  }
+}
+
+.rooms {
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
+
+.room {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+
+  header {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+    gap: 1rem;
+  }
+
+  .location {
+    color: #667085;
+  }
+
+  .description {
+    color: #475467;
+    line-height: 1.5;
+  }
+
+  .meta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+  }
+
+  .badge {
+    padding: 0.35rem 0.75rem;
+    border-radius: 999px;
+    background: rgba(15, 23, 42, 0.08);
+    font-weight: 600;
+    color: #1d2939;
+
+    &--green {
+      background: rgba(34, 197, 94, 0.18);
+      color: #15803d;
+    }
+  }
+}
+
+.loading {
+  text-align: center;
+  color: #475467;
+}

--- a/frontend/src/app/features/rooms/rooms-list.component.ts
+++ b/frontend/src/app/features/rooms/rooms-list.component.ts
@@ -1,0 +1,47 @@
+import { Component, computed, inject, signal } from '@angular/core';
+import { AsyncPipe, CurrencyPipe, NgFor, NgIf } from '@angular/common';
+import { RouterLink } from '@angular/router';
+import { RoomsService } from '../../core/services/rooms.service';
+import { RoomSummary } from '../../core/models/room.model';
+import { AuthService } from '../../core/services/auth.service';
+
+@Component({
+  standalone: true,
+  selector: 'app-rooms-list',
+  templateUrl: './rooms-list.component.html',
+  styleUrl: './rooms-list.component.scss',
+  imports: [NgIf, NgFor, CurrencyPipe, RouterLink, AsyncPipe]
+})
+export class RoomsListComponent {
+  private readonly roomsService = inject(RoomsService);
+  private readonly authService = inject(AuthService);
+
+  readonly rooms = signal<RoomSummary[]>([]);
+  readonly loading = signal<boolean>(false);
+  readonly cityFilter = signal<string>('');
+  readonly onlyPublished = signal<boolean>(true);
+
+  readonly filteredRooms = computed(() => {
+    return this.rooms()
+      .filter((room) => !this.onlyPublished() || room.isPublished)
+      .filter((room) =>
+        !this.cityFilter() ? true : `${room.city}, ${room.country}`.toLowerCase().includes(this.cityFilter().toLowerCase())
+      );
+  });
+
+  constructor() {
+    this.loadRooms();
+  }
+
+  loadRooms(): void {
+    this.loading.set(true);
+    const seekerId = this.authService.currentUser()?.id;
+    this.roomsService.listRooms(seekerId ?? undefined).subscribe({
+      next: (rooms) => {
+        this.rooms.set(rooms);
+        this.loading.set(false);
+      },
+      error: () => this.loading.set(false)
+    });
+  }
+}

--- a/frontend/src/environments/environment.development.ts
+++ b/frontend/src/environments/environment.development.ts
@@ -1,0 +1,4 @@
+export const environment = {
+  production: false,
+  apiUrl: 'http://localhost:5000/api'
+};

--- a/frontend/src/environments/environment.ts
+++ b/frontend/src/environments/environment.ts
@@ -1,0 +1,4 @@
+export const environment = {
+  production: true,
+  apiUrl: 'http://localhost:5000/api'
+};

--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>RoomieMatch</title>
+  <base href="/">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="icon" type="image/x-icon" href="favicon.ico">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+</head>
+<body>
+  <app-root></app-root>
+</body>
+</html>

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -1,0 +1,5 @@
+import { bootstrapApplication } from '@angular/platform-browser';
+import { AppComponent } from './app/app.component';
+import { appConfig } from './app/app.config';
+
+bootstrapApplication(AppComponent, appConfig).catch((err) => console.error(err));

--- a/frontend/src/polyfills.ts
+++ b/frontend/src/polyfills.ts
@@ -1,0 +1,1 @@
+import 'zone.js/testing';

--- a/frontend/src/styles.scss
+++ b/frontend/src/styles.scss
@@ -1,0 +1,78 @@
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  margin: 0;
+  padding: 0;
+  font-family: 'Inter', sans-serif;
+  background-color: #f8fafc;
+  color: #101828;
+}
+
+a {
+  color: inherit;
+}
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  margin: 0;
+  font-weight: 600;
+  color: #101828;
+}
+
+p {
+  margin: 0;
+  color: #475467;
+}
+
+.container {
+  max-width: 1100px;
+  margin: 0 auto;
+  width: 100%;
+}
+
+.card {
+  background: #fff;
+  border-radius: 1rem;
+  border: 1px solid #e4e7ec;
+  padding: 1.5rem;
+  box-shadow: 0 10px 35px -30px rgba(15, 23, 42, 0.35);
+}
+
+.form-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+
+  label {
+    font-weight: 600;
+    color: #344054;
+  }
+
+  input,
+  textarea,
+  select {
+    padding: 0.75rem;
+    border-radius: 0.65rem;
+    border: 1px solid #d0d5dd;
+    font: inherit;
+    background: #fff;
+  }
+}
+
+.grid {
+  display: grid;
+  gap: 1.5rem;
+}
+
+@media (max-width: 720px) {
+  .card {
+    padding: 1.25rem;
+  }
+}

--- a/frontend/src/test.ts
+++ b/frontend/src/test.ts
@@ -1,0 +1,1 @@
+import 'zone.js/testing';

--- a/frontend/tsconfig.app.json
+++ b/frontend/tsconfig.app.json
@@ -1,0 +1,13 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist/out-tsc/app",
+    "types": []
+  },
+  "files": [
+    "src/main.ts"
+  ],
+  "include": [
+    "src/**/*.d.ts"
+  ]
+}

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,31 @@
+{
+  "compileOnSave": false,
+  "compilerOptions": {
+    "baseUrl": "./",
+    "outDir": "./dist/out-tsc",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "sourceMap": true,
+    "declaration": false,
+    "downlevelIteration": true,
+    "experimentalDecorators": true,
+    "moduleResolution": "node",
+    "module": "es2022",
+    "target": "es2022",
+    "useDefineForClassFields": false,
+    "lib": [
+      "es2022",
+      "dom"
+    ]
+  },
+  "angularCompilerOptions": {
+    "enableI18nLegacyMessageIdFormat": false,
+    "strictInjectionParameters": true,
+    "strictInputAccessModifiers": true,
+    "strictTemplates": true
+  }
+}

--- a/frontend/tsconfig.spec.json
+++ b/frontend/tsconfig.spec.json
@@ -1,0 +1,17 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist/out-tsc/spec",
+    "types": [
+      "jasmine"
+    ]
+  },
+  "files": [
+    "src/test.ts",
+    "src/polyfills.ts"
+  ],
+  "include": [
+    "src/**/*.spec.ts",
+    "src/**/*.d.ts"
+  ]
+}


### PR DESCRIPTION
## Summary
- scaffold an Angular 17 SPA with routing, layout shell, and feature pages for landing, rooms, dashboard, requests, and profile management
- implement API-backed services, authentication handling, guards, and booking interactions against the existing backend endpoints
- document frontend setup instructions and include a static preview asset for quick visual verification

## Testing
- not run (npm registry access is blocked in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68e37fc4d10883329c202349dadf4ab8