### PR TITLE
Fix Angular workspace config and lint dependency

### DIFF
--- a/frontend/angular.json
+++ b/frontend/angular.json
@@ -1,7 +1,6 @@
 {
   "$schema": "./node_modules/@angular/cli/lib/config/schema.json",
   "version": 1,
-  "defaultProject": "roomiematch",
   "projects": {
     "roomiematch": {
       "projectType": "application",
@@ -82,5 +81,9 @@
         }
       }
     }
+  },
+  "cli": {
+    "defaultProject": "roomiematch",
+    "analytics": false
   }
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -28,6 +28,7 @@
     "@angular-eslint/eslint-plugin": "^17.4.1",
     "@angular-eslint/eslint-plugin-template": "^17.4.1",
     "@angular-eslint/template-parser": "^17.4.1",
+    "@typescript-eslint/parser": "^7.11.0",
     "@angular/cli": "^17.3.1",
     "@angular/compiler-cli": "^17.3.0",
     "@types/jasmine": "~5.1.0",


### PR DESCRIPTION
## Summary
- move the Angular CLI default project setting into the supported `cli` extension to silence workspace warnings
- declare `@typescript-eslint/parser` so the Angular ESLint inline template processor can resolve its parser

## Testing
- dotnet test *(fails: .NET SDK is not installed in the execution environment)*
- npm test -- --watch=false *(fails: no Chrome/Chromium binary available in the execution environment)*
- npm run lint *(fails: the newly-declared parser dependency is not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e3b2d148548332b300bd1b540207df