### PR TITLE
Fix package restore failure by updating MediatR version

### DIFF
--- a/backend/RoomieMatch.Api/RoomieMatch.Api.csproj
+++ b/backend/RoomieMatch.Api/RoomieMatch.Api.csproj
@@ -19,6 +19,6 @@
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
     <PackageReference Include="FluentValidation.AspNetCore" Version="11.3.0" />
     <PackageReference Include="Serilog.AspNetCore" Version="8.0.1" />
-    <PackageReference Include="MediatR" Version="12.1.1" />
+    <PackageReference Include="MediatR" Version="12.2.0" />
   </ItemGroup>
 </Project>

--- a/backend/RoomieMatch.Application/RoomieMatch.Application.csproj
+++ b/backend/RoomieMatch.Application/RoomieMatch.Application.csproj
@@ -9,7 +9,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="FluentValidation" Version="11.9.0" />
-    <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="12.1.1" />
+    <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="12.2.0" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="9.0.0-preview.2.24128.4" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
- update the MediatR packages to version 12.2.0 so restore can locate the dependencies

## Testing
- not run (dotnet CLI is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68e40e72c1388332b1a5a2ab729f9ecc